### PR TITLE
Allow instalation using pip

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,24 @@
+"""
+pyflit 
+
+Pyflit is a simple Python HTTP downloader.
+"""
+
+from setuptools import setup, find_packages
+import pyflit
+
+setup(
+    name="pyflit",
+    author="Galeo Tian",
+    description="Pyflit is a simple Python HTTP downloader.",
+    license="GNU General Public License",
+    url="https://github.com/galeo/pyflit",
+    packages=pyflit,
+    classifiers=[
+        "Development Status :: 5 - Production/Stable",
+        "Topic :: Software Development :: Libraries",
+        "License :: OSI Approved :: GNU General Public License (GPL)",
+    ],
+    install_requires=[
+        ],
+)

--- a/setup.py
+++ b/setup.py
@@ -4,16 +4,17 @@ pyflit
 Pyflit is a simple Python HTTP downloader.
 """
 
-from setuptools import setup, find_packages
+from setuptools import setup
 import pyflit
 
 setup(
     name="pyflit",
+    version=1.0,
     author="Galeo Tian",
     description="Pyflit is a simple Python HTTP downloader.",
     license="GNU General Public License",
     url="https://github.com/galeo/pyflit",
-    packages=pyflit,
+    packages=["pyflit"],
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Topic :: Software Development :: Libraries",

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,4 @@ setup(
         "Topic :: Software Development :: Libraries",
         "License :: OSI Approved :: GNU General Public License (GPL)",
     ],
-    install_requires=[
-        ],
 )


### PR DESCRIPTION
This pull requests adds a setup.py file, allowing pyflit to be installed automatically.

```
$ pip install git+git://github.com/galeo/pyflit
Collecting git+git://github.com/galeo/pyflit
  Cloning git://github.com/galeo/pyflit to /private/var/folders/xf/tgb7k0gs4fbchk8p3v0y9xz00000gn/T/pip-BFBcUC-build
Installing collected packages: pyflit
  Running setup.py install for pyflit ... done
Successfully installed pyflit-1.0
$ 
```